### PR TITLE
Added ability to specify scale in <gantt> constructor.

### DIFF
--- a/gantt_improvement/static/src/js/gantt.js
+++ b/gantt_improvement/static/src/js/gantt.js
@@ -265,6 +265,9 @@ openerp.gantt_improvement = function (instance) {
             if (this.attrs.string !== undefined) {
                 label = this.attrs.string;
             }
+            if (this.attrs.scale !== undefined) {
+                self.set_scale(this.attrs.scale);
+            }
             gantt.config.columns = [
                 {name: "text", label: label, width:"*", tree:true}
             ];


### PR DESCRIPTION
I couldn't find an easy way to do this by default so I added a setting called "scale" to the <gantt> constructor. For example in GanttView you can have it default to the "Year" view by doing this: <gantt scale="4"/>. The values are day = 1, week = 2, month = 3 & year = 4.
