### PR TITLE
Bug fix

### DIFF
--- a/gantt_improvement/static/src/js/gantt.js
+++ b/gantt_improvement/static/src/js/gantt.js
@@ -315,9 +315,8 @@ openerp.gantt_improvement = function (instance) {
                         item_parent_id = 'p' + 0;
                         item_parent_name = 'Gantt View';
                     } else if (item[group_bys[0]] !== undefined) {
-
-                        item_parent_id = 'p' + item[group_bys][0];
-                        item_parent_name = item[group_bys][1];
+                        item_parent_id = 'p' + item[group_bys[0]];
+                        item_parent_name = item[group_bys[1]];
                     }
 
                     if (parents[item_parent_id] === undefined) {


### PR DESCRIPTION
We had an issue with one of our customers Odoo getting an "Uncaught TypeError: Cannot read property '0' of undefined" error. I traced it back to this section and noticed that you were checking if item[group_bys[0]] was defined but then assigning item[group_bys][0]. I fixed this and the line after. After this the error went away.
